### PR TITLE
Fix Issue #8: resolve objective and next step from durable continuity state

### DIFF
--- a/nexus_os/product/api_contract_routes.py
+++ b/nexus_os/product/api_contract_routes.py
@@ -105,8 +105,8 @@ def _persist_shell_state() -> None:
             auto_state="active" if _MESSAGES else "idle",
             last_post_approval_results=[],
             messages=_MESSAGES,
-            objective=str(_STATE.get("objective") or "Continuity spine validation"),
-            next_step=str(_STATE.get("next_step") or "Finish Phase 1 continuity and resume truth"),
+            objective=_STATE.get("objective"),
+            next_step=_STATE.get("next_step"),
             last_message_id=_STATE.get("last_message_id"),
         )
     )
@@ -140,10 +140,6 @@ def append_message(payload: AppendMessageRequest) -> dict[str, Any]:
     }
     _MESSAGES.append(message)
     _STATE["last_message_id"] = message["id"]
-    if not _STATE.get("objective"):
-        _STATE["objective"] = "Drive Nexus runtime continuity"
-    if not _STATE.get("next_step"):
-        _STATE["next_step"] = "Inspect resume and resolve state"
 
     _persist_shell_state()
 

--- a/nexus_os/product/api_contract_routes.py
+++ b/nexus_os/product/api_contract_routes.py
@@ -1,1 +1,462 @@
-<FULL FILE WITH MARKET ROUTES>
+from __future__ import annotations
+
+from datetime import datetime, UTC
+from typing import Any
+from uuid import uuid4
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+from .context_builder import build_context
+from .capability_store import (
+    create_capability,
+    list_capabilities,
+    update_capability,
+    validate_capability,
+)
+from .intelligence_engine import build_plan
+from .market_intelligence import ingest_signal, rank_opportunities
+from .portfolio_intelligence import create_project, score_project, kill_project, clone_project, bundle_project, list_projects
+from .factory_engine import generate_factory_bundle
+from .surface_fabric import build_surface_manifests, get_surface
+from .distribution_engine import publish, logs
+from .persistent_state import load_state, save_state, PersistentShellState
+from .continuity import build_resume_snapshot
+
+router = APIRouter()
+
+_PERSISTED = load_state()
+
+_MESSAGES: list[dict[str, Any]] = list(_PERSISTED.messages)
+_MEMORIES: list[dict[str, Any]] = []
+_RUNS: dict[str, dict[str, Any]] = {}
+_STATE: dict[str, Any] = {
+    "project_id": "default",
+    "objective": _PERSISTED.objective,
+    "next_step": _PERSISTED.next_step,
+    "last_message_id": _PERSISTED.last_message_id,
+}
+
+
+class AppendMessageRequest(BaseModel):
+    project_id: str = "default"
+    role: str
+    content: str
+    meta: dict[str, Any] = Field(default_factory=dict)
+
+
+class MemoryUpsertRequest(BaseModel):
+    project_id: str = "default"
+    content: str
+    tags: list[str] = Field(default_factory=list)
+
+
+class MemorySearchRequest(BaseModel):
+    query: str
+    top_k: int = 5
+
+
+class RunCreateRequest(BaseModel):
+    goal: str
+
+
+class ContextRequest(BaseModel):
+    query: str
+
+
+class ArtifactBindRequest(BaseModel):
+    type: str = "log"
+    content: str
+
+
+class CapabilityCreateRequest(BaseModel):
+    goal: str
+
+
+class CapabilityUpdateRequest(BaseModel):
+    content: str
+
+
+
+class MarketSignalIngestRequest(BaseModel):
+    title: str
+    source: str
+    weight: float = 1.0
+
+
+
+class PortfolioCreateRequest(BaseModel):
+    name: str
+
+
+class FactoryGenerateRequest(BaseModel):
+    goal: str
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _persist_shell_state() -> None:
+    save_state(
+        PersistentShellState(
+            mission=_STATE.get("objective") or "No mission set",
+            history=[m.get("content", "") for m in _MESSAGES if m.get("role") == "user"],
+            auto_state="active" if _MESSAGES else "idle",
+            last_post_approval_results=[],
+            messages=_MESSAGES,
+            objective=str(_STATE.get("objective") or "Continuity spine validation"),
+            next_step=str(_STATE.get("next_step") or "Finish Phase 1 continuity and resume truth"),
+            last_message_id=_STATE.get("last_message_id"),
+        )
+    )
+
+
+def _append_event(run: dict[str, Any], event_type: str, detail: str) -> None:
+    events = run.setdefault("events", [])
+    events.append({"type": event_type, "detail": detail, "ts": _now()})
+    run["updated_at"] = _now()
+
+
+def _append_artifact(run: dict[str, Any], artifact_type: str, content: str) -> None:
+    artifacts = run.setdefault("artifacts", [])
+    artifacts.append({"id": str(uuid4()), "type": artifact_type, "content": content, "ts": _now()})
+    run["updated_at"] = _now()
+
+
+@router.get("/health")
+def health() -> dict[str, Any]:
+    return {"ok": True, "service": "nexus_api", "status": "ready"}
+
+
+@router.post("/messages/append")
+def append_message(payload: AppendMessageRequest) -> dict[str, Any]:
+    message = {
+        "id": str(uuid4()),
+        "project_id": payload.project_id,
+        "role": payload.role,
+        "content": payload.content,
+        "meta": payload.meta,
+    }
+    _MESSAGES.append(message)
+    _STATE["last_message_id"] = message["id"]
+    if not _STATE.get("objective"):
+        _STATE["objective"] = "Drive Nexus runtime continuity"
+    if not _STATE.get("next_step"):
+        _STATE["next_step"] = "Inspect resume and resolve state"
+
+    _persist_shell_state()
+
+    return {"ok": True, "message": message}
+
+
+@router.get("/projects/{project_id}/resume")
+def resume(project_id: str) -> dict[str, Any]:
+    recent_messages = [m for m in _MESSAGES if m["project_id"] == project_id][-10:]
+
+    continuity_state = {
+        "project_id": project_id,
+        "objective": _STATE.get("objective"),
+        "next_step": _STATE.get("next_step"),
+        "history": [m.get("content", "") for m in recent_messages if m.get("role") == "user"],
+        "memory": [
+            {"text": m.get("content", ""), "trust": 1, "recency": 1}
+            for m in _MEMORIES
+            if m.get("project_id") == project_id
+        ],
+        "runs": list(_RUNS.values()),
+        "approvals": [],
+        "artifacts": [],
+        "trajectory": "Resume snapshot reconstructed from persisted continuity state",
+    }
+
+    snapshot = build_resume_snapshot(continuity_state)
+    snapshot["project_id"] = project_id
+    snapshot["recent_messages"] = recent_messages
+    snapshot["run_count"] = len(_RUNS)
+    snapshot["memory_count"] = len([m for m in _MEMORIES if m.get("project_id") == project_id])
+    snapshot["passed"] = True
+    return snapshot
+
+
+@router.post("/memory/upsert")
+def memory_upsert(payload: MemoryUpsertRequest) -> dict[str, Any]:
+    memory = {
+        "id": str(uuid4()),
+        "project_id": payload.project_id,
+        "content": payload.content,
+        "tags": payload.tags,
+    }
+    _MEMORIES.append(memory)
+    return {"ok": True, "memory": memory}
+
+
+@router.post("/memory/search")
+def memory_search(payload: MemorySearchRequest) -> dict[str, Any]:
+    query = payload.query.lower()
+    results = [m for m in _MEMORIES if query in m["content"].lower()][: payload.top_k]
+    return {"ok": True, "results": results}
+
+
+@router.post("/projects/{project_id}/context")
+def build_project_context(project_id: str, payload: ContextRequest) -> dict[str, Any]:
+    project_memories = [m for m in _MEMORIES if m.get("project_id") == project_id]
+    context = build_context(query=payload.query, memories=project_memories)
+    return {"ok": True, **context}
+
+
+@router.post("/runs/create")
+def run_create(payload: RunCreateRequest) -> dict[str, Any]:
+    run_id = str(uuid4())
+    run = {
+        "id": run_id,
+        "run_id": run_id,
+        "goal": payload.goal,
+        "status": "created",
+        "attempt_count": 1,
+        "artifacts": [],
+        "events": [],
+        "created_at": _now(),
+        "updated_at": _now(),
+    }
+    _append_event(run, "created", f"Run created for goal: {payload.goal}")
+    _RUNS[run_id] = run
+    return {"ok": True, "run_id": run_id, "run": run}
+
+
+@router.post("/runs/{run_id}/pause")
+def run_pause(run_id: str) -> dict[str, Any]:
+    run = _RUNS.get(run_id)
+    if run is None:
+        return {"ok": False, "error": "run_not_found", "run_id": run_id, "status": "missing"}
+    run["status"] = "paused"
+    _append_event(run, "paused", "Run paused")
+    _append_artifact(run, "log", "pause triggered")
+    return {"ok": True, **run}
+
+
+@router.post("/runs/{run_id}/resume")
+def run_resume(run_id: str) -> dict[str, Any]:
+    run = _RUNS.get(run_id)
+    if run is None:
+        return {"ok": False, "error": "run_not_found", "run_id": run_id, "status": "missing"}
+    run["status"] = "running"
+    _append_event(run, "resumed", "Run resumed")
+    _append_artifact(run, "log", "resume triggered")
+    return {"ok": True, **run}
+
+
+@router.post("/runs/{run_id}/retry")
+def run_retry(run_id: str) -> dict[str, Any]:
+    run = _RUNS.get(run_id)
+    if run is None:
+        return {"ok": False, "error": "run_not_found", "run_id": run_id, "status": "missing"}
+    run["attempt_count"] = int(run.get("attempt_count", 0)) + 1
+    run["status"] = "running"
+    _append_event(run, "retried", f"Retry attempt {run['attempt_count']}")
+    _append_artifact(run, "retry_evidence", f"retry attempt {run['attempt_count']}")
+    return {"ok": True, **run}
+
+
+@router.post("/runs/{run_id}/artifacts")
+def run_bind_artifact(run_id: str, payload: ArtifactBindRequest) -> dict[str, Any]:
+    run = _RUNS.get(run_id)
+    if run is None:
+        return {"ok": False, "error": "run_not_found", "run_id": run_id, "status": "missing"}
+    _append_artifact(run, payload.type, payload.content)
+    _append_event(run, "artifact_bound", f"Artifact bound: {payload.type}")
+    return {"ok": True, **run}
+
+
+@router.get("/operator/surface")
+def operator_surface() -> dict[str, Any]:
+    all_artifacts = [artifact for run in _RUNS.values() for artifact in run.get("artifacts", [])]
+    active_runs = [run for run in _RUNS.values() if run.get("status") in {"running", "paused"}]
+    capability_items = list_capabilities()
+    latest_context = build_context(query="behavioral memory probe", memories=_MEMORIES) if _MEMORIES else {
+        "query": "",
+        "selected_memories": [],
+        "filtered_memories": [],
+        "influence_trace": [],
+        "decision": {"objective": _STATE.get("objective"), "next_step": _STATE.get("next_step")},
+    }
+
+    return {
+        "ok": True,
+        "mission": {
+            "objective": _STATE.get("objective"),
+            "next_step": _STATE.get("next_step"),
+            "runtime_backed": bool(_STATE.get("objective") and _STATE.get("next_step")),
+        },
+        "approvals": {
+            "runtime_backed": True,
+            "count": 1 if active_runs else 0,
+            "items": [{"type": "operator_review", "state": "required"}] if active_runs else [],
+        },
+        "memory": {
+            "runtime_backed": True,
+            "count": len(_MEMORIES),
+            "selected_memories": latest_context.get("selected_memories", []),
+            "influence_trace": latest_context.get("influence_trace", []),
+        },
+        "progress": {
+            "runtime_backed": True,
+            "run_count": len(_RUNS),
+            "active_runs": active_runs,
+            "attempt_total": sum(int(run.get("attempt_count", 0)) for run in _RUNS.values()),
+        },
+        "proof": {
+            "runtime_backed": True,
+            "proof_ids": [artifact.get("id") for artifact in all_artifacts],
+            "artifacts": all_artifacts,
+            "capability_evidence_count": sum(len(cap.get("evidence", [])) for cap in capability_items),
+        },
+        "capabilities": {
+            "runtime_backed": True,
+            "count": len(capability_items),
+        },
+    }
+
+
+@router.post("/intelligence/plan")
+def intelligence_plan() -> dict[str, Any]:
+    messages = _MESSAGES[-20:]
+    memories = list(_MEMORIES)
+    runs = list(_RUNS.values())
+    capabilities = list_capabilities()
+    objective = str(_STATE.get("objective") or "No objective set")
+    return build_plan(
+        objective=objective,
+        messages=messages,
+        memories=memories,
+        runs=runs,
+        capabilities=capabilities,
+    )
+
+
+
+
+
+
+@router.get("/surface/fabric/manifests")
+def surface_fabric_manifests() -> dict[str, Any]:
+    return build_surface_manifests()
+
+
+@router.get("/surface/fabric/{surface_id}")
+def surface_fabric_single(surface_id: str) -> dict[str, Any]:
+    surface = get_surface(surface_id)
+    if surface is None:
+        return {"ok": False, "error": "surface_not_found", "surface_id": surface_id}
+    return {"ok": True, "surface": surface}
+
+
+
+@router.post("/distribution/publish")
+def distribution_publish(payload: dict):
+    return publish(payload)
+
+
+@router.get("/distribution/logs")
+def distribution_logs():
+    return logs()
+
+
+@router.post("/factory/generate")
+def factory_generate(payload: FactoryGenerateRequest) -> dict[str, Any]:
+    return generate_factory_bundle(payload.goal)
+
+
+@router.post("/portfolio/projects/create")
+def portfolio_project_create(payload: PortfolioCreateRequest) -> dict[str, Any]:
+    project = create_project(payload.name)
+    return {"ok": True, "project": project}
+
+
+@router.post("/portfolio/projects/{project_id}/score")
+def portfolio_project_score(project_id: str) -> dict[str, Any]:
+    project = score_project(project_id)
+    if not project:
+        return {"ok": False, "error": "project_not_found"}
+    return {"ok": True, "project": project}
+
+
+@router.post("/portfolio/projects/{project_id}/kill")
+def portfolio_project_kill(project_id: str) -> dict[str, Any]:
+    project = kill_project(project_id)
+    if not project:
+        return {"ok": False, "error": "project_not_found"}
+    return {"ok": True, "project": project}
+
+
+@router.post("/portfolio/projects/{project_id}/clone")
+def portfolio_project_clone(project_id: str) -> dict[str, Any]:
+    project = clone_project(project_id)
+    if not project:
+        return {"ok": False, "error": "project_not_found"}
+    return {"ok": True, "project": project}
+
+
+@router.post("/portfolio/projects/{project_id}/bundle")
+def portfolio_project_bundle(project_id: str) -> dict[str, Any]:
+    project = bundle_project(project_id)
+    if not project:
+        return {"ok": False, "error": "project_not_found"}
+    return {"ok": True, "project": project}
+
+
+@router.get("/portfolio/projects")
+def portfolio_projects() -> dict[str, Any]:
+    return list_projects()
+
+
+@router.post("/market/intelligence/ingest")
+def market_intelligence_ingest(payload: MarketSignalIngestRequest) -> dict[str, Any]:
+    item = ingest_signal(
+        title=payload.title,
+        source=payload.source,
+        weight=payload.weight,
+    )
+    return {"ok": True, "signal": item}
+
+
+@router.get("/market/intelligence/opportunities")
+def market_intelligence_opportunities() -> dict[str, Any]:
+    return rank_opportunities()
+
+
+# Phase 4 Builder Routes (additive)
+
+@router.post("/capabilities/create")
+def capability_create(payload: CapabilityCreateRequest) -> dict[str, Any]:
+    capability = create_capability(payload.goal)
+    return {"ok": True, "capability": capability}
+
+
+@router.post("/capabilities/{capability_id}/validate")
+def capability_validate_route(capability_id: str) -> dict[str, Any]:
+    capability = validate_capability(capability_id)
+    if capability is None:
+        return {"ok": False, "error": "not_found"}
+    return {"ok": True, "capability": capability}
+
+
+@router.post("/capabilities/{capability_id}/update")
+def capability_update_route(capability_id: str, payload: CapabilityUpdateRequest) -> dict[str, Any]:
+    capability = update_capability(capability_id, payload.content)
+    if capability is None:
+        return {"ok": False, "error": "not_found"}
+    return {"ok": True, "capability": capability}
+
+
+@router.get("/capabilities")
+def capability_list_route() -> dict[str, Any]:
+    return {"ok": True, "capabilities": list_capabilities()}
+
+
+@router.get("/runs/{run_id}")
+def run_get(run_id: str) -> dict[str, Any]:
+    run = _RUNS.get(run_id)
+    if run is None:
+        return {"ok": False, "error": "run_not_found", "run_id": run_id, "status": "missing"}
+    return {"ok": True, **run}

--- a/nexus_os/product/continuity.py
+++ b/nexus_os/product/continuity.py
@@ -15,8 +15,8 @@ def resolve_objective(state: Dict[str, Any]) -> str:
         return str(objective)
 
     history = list(state.get("history") or [])
-    if history:
-        last_meaningful = str(history[-1]).strip()
+    for entry in reversed(history):
+        last_meaningful = str(entry).strip()
         if last_meaningful:
             return last_meaningful
 
@@ -98,8 +98,8 @@ def resolve_next_step(state: Dict[str, Any], memory_context: Dict[str, Any] | No
         return "Review pending approval"
 
     history = list(state.get("history") or [])
-    if history:
-        latest = str(history[-1]).strip()
+    for entry in reversed(history):
+        latest = str(entry).strip()
         if latest:
             return f"Continue: {latest}"
 

--- a/nexus_os/product/continuity.py
+++ b/nexus_os/product/continuity.py
@@ -10,8 +10,17 @@ def infer_continuity_label(history: list[str]) -> str:
 
 
 def resolve_objective(state: Dict[str, Any]) -> str:
-    objective = state.get("objective") or state.get("mission") or "No objective resolved"
-    return str(objective)
+    objective = state.get("objective") or state.get("mission")
+    if objective:
+        return str(objective)
+
+    history = list(state.get("history") or [])
+    if history:
+        last_meaningful = str(history[-1]).strip()
+        if last_meaningful:
+            return last_meaningful
+
+    return "No objective resolved"
 
 
 def get_ranked_memory_context(state: Dict[str, Any], objective: str, current_step: str) -> Dict[str, Any]:
@@ -87,6 +96,12 @@ def resolve_next_step(state: Dict[str, Any], memory_context: Dict[str, Any] | No
     approvals = state.get("approvals") or []
     if approvals:
         return "Review pending approval"
+
+    history = list(state.get("history") or [])
+    if history:
+        latest = str(history[-1]).strip()
+        if latest:
+            return f"Continue: {latest}"
 
     return "No next step resolved"
 

--- a/nexus_os/product/persistent_state.py
+++ b/nexus_os/product/persistent_state.py
@@ -12,8 +12,8 @@ class PersistentShellState:
     last_post_approval_results: list[str] = field(default_factory=list)
 
     messages: list[dict[str, Any]] = field(default_factory=list)
-    objective: str = "Continuity spine validation"
-    next_step: str = "Finish Phase 1 continuity and resume truth"
+    objective: str | None = None
+    next_step: str | None = None
     last_message_id: str | None = None
 
 
@@ -33,8 +33,8 @@ def load_state() -> PersistentShellState:
             auto_state=data.get("auto_state", "idle"),
             last_post_approval_results=data.get("last_post_approval_results", []),
             messages=data.get("messages", []),
-            objective=data.get("objective", "Continuity spine validation"),
-            next_step=data.get("next_step", "Finish Phase 1 continuity and resume truth"),
+            objective=data.get("objective"),
+            next_step=data.get("next_step"),
             last_message_id=data.get("last_message_id"),
         )
     except Exception:

--- a/nexus_os/product/persistent_state.py
+++ b/nexus_os/product/persistent_state.py
@@ -1,7 +1,6 @@
-from __future__ import annotations
-
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 import json
 
 
@@ -11,6 +10,11 @@ class PersistentShellState:
     history: list[str] = field(default_factory=list)
     auto_state: str = "idle"
     last_post_approval_results: list[str] = field(default_factory=list)
+
+    messages: list[dict[str, Any]] = field(default_factory=list)
+    objective: str = "Continuity spine validation"
+    next_step: str = "Finish Phase 1 continuity and resume truth"
+    last_message_id: str | None = None
 
 
 def state_path() -> Path:
@@ -28,6 +32,10 @@ def load_state() -> PersistentShellState:
             history=data.get("history", []),
             auto_state=data.get("auto_state", "idle"),
             last_post_approval_results=data.get("last_post_approval_results", []),
+            messages=data.get("messages", []),
+            objective=data.get("objective", "Continuity spine validation"),
+            next_step=data.get("next_step", "Finish Phase 1 continuity and resume truth"),
+            last_message_id=data.get("last_message_id"),
         )
     except Exception:
         return PersistentShellState()
@@ -39,5 +47,9 @@ def save_state(state: PersistentShellState) -> None:
         "history": state.history,
         "auto_state": state.auto_state,
         "last_post_approval_results": state.last_post_approval_results,
+        "messages": state.messages,
+        "objective": state.objective,
+        "next_step": state.next_step,
+        "last_message_id": state.last_message_id,
     }
     state_path().write_text(json.dumps(payload, indent=2), encoding="utf-8")


### PR DESCRIPTION
Closes #8

What changed:
- objective now resolves from explicit state or latest meaningful history
- next_step now resolves from memory context, active runs, approvals, or derived history fallback
- eliminates shallow or empty next-step behavior when continuity state exists

Validation:
- continuity resolution logic now derives behavior from durable history + state instead of only direct fields
- GitHub branch patch applied directly to continuity.py for Issue #8