### PR TITLE
Repo truth hygiene: archive policy + validator + clean baseline

### DIFF
--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -1,0 +1,30 @@
+# Documentation Archive
+
+This directory is for historical Nexus documentation that should remain available but must not be treated as current launch truth.
+
+## Current authority
+
+Current release truth is governed in this order:
+
+1. GitHub CI on main
+2. scripts/run_enterprise_gate.py
+3. final certification output
+4. validator outputs
+5. issue closure matrix
+6. active documentation
+
+The current release status is maintained in:
+
+- docs/release/CURRENT_STATUS.md
+- docs/release/ENTERPRISE_BLOCKERS.md
+- docs/ui/NEXUS_UI_MASTER_TRUTH.md
+
+## Archive rule
+
+A document belongs here when it is useful historical context but contains stale status claims, superseded phase plans, old blocker language, pre-certification launch posture, or duplicate release narratives that conflict with the current evidence-certified state.
+
+Archived documents must not be used to override current CI, gate, validator, or certification evidence.
+
+## Required banner for archived documents
+
+Historical archive. This document predates the current evidence-certified release state and is not current launch truth. Current authority: docs/release/CURRENT_STATUS.md.

--- a/scripts/validate_docs_truth_hygiene.py
+++ b/scripts/validate_docs_truth_hygiene.py
@@ -1,49 +1,113 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 
-BANNED = [
+CANONICAL_FILES = [
+    ROOT / "docs/release/CURRENT_STATUS.md",
+    ROOT / "docs/release/ENTERPRISE_BLOCKERS.md",
+    ROOT / "docs/ui/NEXUS_UI_MASTER_TRUTH.md",
+]
+
+CURRENT_STATUS = ROOT / "docs/release/CURRENT_STATUS.md"
+
+ACTIVE_STALE_PATTERNS = [
     "Status: NO-GO",
     "Status: RED",
     "Status: OPEN",
-    "DRAFT",
+    "GitHub Actions: RED",
+    "NOT MERGE READY",
 ]
 
-ALLOW_CONTEXT = [
+DRAFT_PATTERNS = [
+    "DRAFT UNTIL IMPLEMENTED",
+    "Status: DRAFT",
+]
+
+ALLOW_TERMS = [
+    "archived",
     "archive",
     "historical",
+    "stale",
+    "superseded",
+    "example",
+    "quoted",
+    "pre-pr #49",
     "pre_pr49",
+    "non-blocking",
 ]
 
-SEARCH_PATHS = [ROOT / "docs"]
+SEARCH_ROOTS = [ROOT / "docs"]
 
 
-def is_allowed(text):
-    lower = text.lower()
-    return any(a in lower for a in ALLOW_CONTEXT)
+def is_archive_path(path: Path) -> bool:
+    try:
+        path.relative_to(ROOT / "docs/archive")
+        return True
+    except ValueError:
+        return False
 
 
-def scan():
-    violations = []
-    for base in SEARCH_PATHS:
-        for path in base.rglob("*.md"):
-            if "docs/archive" in str(path):
-                continue
-            try:
-                text = path.read_text(encoding="utf-8")
-            except Exception:
-                continue
-            for b in BANNED:
-                if b in text and not is_allowed(text):
-                    violations.append(str(path))
+def nearby_context(lines: list[str], index: int) -> str:
+    start = max(0, index - 1)
+    end = min(len(lines), index + 2)
+    return "\n".join(lines[start:end]).lower()
+
+
+def allowed_by_context(lines: list[str], index: int) -> bool:
+    context = nearby_context(lines, index)
+    return any(term in context for term in ALLOW_TERMS)
+
+
+def validate_required_files() -> list[str]:
+    violations: list[str] = []
+    for path in CANONICAL_FILES:
+        if not path.exists():
+            violations.append(f"missing canonical file: {path.relative_to(ROOT)}")
+    if CURRENT_STATUS.exists():
+        text = CURRENT_STATUS.read_text(encoding="utf-8")
+        for required in ["CERTIFIED_BY_EVIDENCE", "GREEN"]:
+            if required not in text:
+                violations.append(
+                    f"{CURRENT_STATUS.relative_to(ROOT)}: missing required current status token {required!r}"
+                )
     return violations
 
 
-if __name__ == "__main__":
-    v = scan()
-    if v:
+def validate_markdown_truth() -> list[str]:
+    violations: list[str] = []
+    patterns = ACTIVE_STALE_PATTERNS + DRAFT_PATTERNS
+    for root in SEARCH_ROOTS:
+        for path in root.rglob("*.md"):
+            if is_archive_path(path):
+                continue
+            try:
+                lines = path.read_text(encoding="utf-8").splitlines()
+            except Exception as exc:
+                violations.append(f"{path.relative_to(ROOT)}: could not read file: {exc}")
+                continue
+            for index, line in enumerate(lines):
+                for pattern in patterns:
+                    if pattern in line and not allowed_by_context(lines, index):
+                        violations.append(
+                            f"{path.relative_to(ROOT)}:{index + 1}: active stale truth claim: {pattern}"
+                        )
+    return violations
+
+
+def main() -> int:
+    violations = []
+    violations.extend(validate_required_files())
+    violations.extend(validate_markdown_truth())
+    if violations:
         print("DOCS_TRUTH_HYGIENE_FAIL")
-        for i in v:
-            print(i)
-        exit(1)
+        for violation in violations:
+            print(violation)
+        return 1
     print("DOCS_TRUTH_HYGIENE_PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_docs_truth_hygiene.py
+++ b/scripts/validate_docs_truth_hygiene.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+BANNED = [
+    "Status: NO-GO",
+    "Status: RED",
+    "Status: OPEN",
+    "DRAFT",
+]
+
+ALLOW_CONTEXT = [
+    "archive",
+    "historical",
+    "pre_pr49",
+]
+
+SEARCH_PATHS = [ROOT / "docs"]
+
+
+def is_allowed(text):
+    lower = text.lower()
+    return any(a in lower for a in ALLOW_CONTEXT)
+
+
+def scan():
+    violations = []
+    for base in SEARCH_PATHS:
+        for path in base.rglob("*.md"):
+            if "docs/archive" in str(path):
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except Exception:
+                continue
+            for b in BANNED:
+                if b in text and not is_allowed(text):
+                    violations.append(str(path))
+    return violations
+
+
+if __name__ == "__main__":
+    v = scan()
+    if v:
+        print("DOCS_TRUTH_HYGIENE_FAIL")
+        for i in v:
+            print(i)
+        exit(1)
+    print("DOCS_TRUTH_HYGIENE_PASS")


### PR DESCRIPTION
This PR introduces controlled repo cleanup without risking loss of valid system state.

Changes:
- Adds docs/archive/README.md with formal archive policy
- Adds scripts/validate_docs_truth_hygiene.py
- Establishes safe path for archiving stale docs instead of deleting

Purpose:
- Ensure CURRENT_STATUS.md remains authoritative
- Prevent reintroduction of stale NO-GO/OPEN/RED claims
- Prepare repo for lean, clean, green state without breaking working system

No runtime code changed.
No deletions performed in this pass.

Next phase (separate PR):
- classify and archive stale release docs
- tighten validator rules
- update README to reflect CERTIFIED_BY_EVIDENCE state