### PR TITLE
Add repository bootstrap for scripts; update scripts to use it; add import baseline tests

### DIFF
--- a/docs/release/evidence/STABILIZATION_STATUS.md
+++ b/docs/release/evidence/STABILIZATION_STATUS.md
@@ -1,0 +1,19 @@
+# Stabilization Status
+
+## Import baseline reconciliation (2026-04-25)
+
+- Baseline is `origin/main` at commit `b4eda58`.
+- PR #54 archive cleanup is present in this baseline.
+- Script import baseline is fixed (`scripts/_repo_bootstrap.py` + script bootstrap imports).
+- Required commands pass without `PYTHONPATH=.` from repo root:
+  - `python scripts/run_ui_truth_scenarios.py`
+  - `python scripts/validate_ui_truth.py`
+  - `python scripts/validate_docs_truth_hygiene.py`
+  - `python scripts/validate_repo_truth_consistency.py`
+  - `python scripts/run_enterprise_gate.py`
+  - `python -m pytest tests`
+- UI hover-native work is missing on this baseline.
+
+**Status:** BASELINE CLEAN / UI WORK MISSING.
+
+**Next action:** rerun P0-2 hover-native UI implementation after this branch is merged.

--- a/scripts/_repo_bootstrap.py
+++ b/scripts/_repo_bootstrap.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))

--- a/scripts/run_continuity_scenarios.py
+++ b/scripts/run_continuity_scenarios.py
@@ -5,6 +5,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List
 
+try:
+    import _repo_bootstrap  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover
+    from scripts import _repo_bootstrap  # noqa: F401
 from nexus_os.product.continuity import build_resume_snapshot
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/scripts/run_execution_scenarios.py
+++ b/scripts/run_execution_scenarios.py
@@ -4,6 +4,10 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 
+try:
+    import _repo_bootstrap  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover
+    from scripts import _repo_bootstrap  # noqa: F401
 from nexus_os.product.execution import (
     add_artifact,
     block_run_for_approval,

--- a/scripts/run_memory_behavior_scenarios.py
+++ b/scripts/run_memory_behavior_scenarios.py
@@ -6,6 +6,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+try:
+    import _repo_bootstrap  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover
+    from scripts import _repo_bootstrap  # noqa: F401
 from nexus_os.product.context_builder import build_context
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/scripts/run_memory_context_scenarios.py
+++ b/scripts/run_memory_context_scenarios.py
@@ -6,6 +6,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+try:
+    import _repo_bootstrap  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover
+    from scripts import _repo_bootstrap  # noqa: F401
 from nexus_os.product.context_builder import build_context
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/scripts/run_memory_trace_scenarios.py
+++ b/scripts/run_memory_trace_scenarios.py
@@ -6,6 +6,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+try:
+    import _repo_bootstrap  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover
+    from scripts import _repo_bootstrap  # noqa: F401
 from nexus_os.product.context_builder import build_context
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/scripts/run_ui_truth_scenarios.py
+++ b/scripts/run_ui_truth_scenarios.py
@@ -4,6 +4,10 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 
+try:
+    import _repo_bootstrap  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover
+    from scripts import _repo_bootstrap  # noqa: F401
 from nexus_os.product.continuity import build_resume_snapshot
 from nexus_os.product.execution import create_run
 from nexus_os.product.ui_truth import (

--- a/scripts/validate_nexus_10_10_gate.py
+++ b/scripts/validate_nexus_10_10_gate.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+try:
+    import _repo_bootstrap  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover
+    from scripts import _repo_bootstrap  # noqa: F401
 from nexus_os.governance.ten_ten_gate import run_ten_ten_gate
 
 def main() -> int:

--- a/scripts/validate_nexus_master_truth.py
+++ b/scripts/validate_nexus_master_truth.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+try:
+    import _repo_bootstrap  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover
+    from scripts import _repo_bootstrap  # noqa: F401
 from nexus_os.governance.master_truth_gate import run_master_truth_gate
 
 def main() -> int:

--- a/tests/test_script_import_baseline.py
+++ b/tests/test_script_import_baseline.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_ui_truth_script_runs_without_pythonpath() -> None:
+    result = _run([sys.executable, "scripts/run_ui_truth_scenarios.py"])
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_ui_truth_script_runpy_entrypoint_without_pythonpath() -> None:
+    command = [
+        sys.executable,
+        "-c",
+        "import runpy; runpy.run_path('scripts/run_ui_truth_scenarios.py', run_name='__main__')",
+    ]
+    result = _run(command)
+    assert result.returncode == 0, result.stderr or result.stdout


### PR DESCRIPTION
### Motivation

- Allow repository scripts to be executed from the repository root without requiring `PYTHONPATH=.` and stabilize the script import baseline for release evidence.

### Description

- Add `scripts/_repo_bootstrap.py` which inserts the repository root into `sys.path`.
- Update multiple scripts to import `_repo_bootstrap` with a `ModuleNotFoundError` fallback to preserve prior invocation modes (files updated include `run_continuity_scenarios.py`, `run_execution_scenarios.py`, `run_memory_behavior_scenarios.py`, `run_memory_context_scenarios.py`, `run_memory_trace_scenarios.py`, `run_ui_truth_scenarios.py`, `validate_nexus_10_10_gate.py`, and `validate_nexus_master_truth.py`).
- Replace ad-hoc `sys.path.insert` usage in validation scripts with the centralized bootstrap import.
- Add release evidence file `docs/release/evidence/STABILIZATION_STATUS.md` and a new test file `tests/test_script_import_baseline.py` that verifies `scripts/run_ui_truth_scenarios.py` runs without setting `PYTHONPATH` using both direct execution and a `runpy` entrypoint.

### Testing

- Ran `pytest tests` which included the new `tests/test_script_import_baseline.py` and the test suite passed.
- The new tests assert that `scripts/run_ui_truth_scenarios.py` exits with code `0` when invoked by `python` and via `runpy`, and both assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ec28bdcd60832cb0d5a8393a038f8a)