### PR TITLE
Restore Nexus headless desktop launch

### DIFF
--- a/launch_nexus_desktop.sh
+++ b/launch_nexus_desktop.sh
@@ -1,36 +1,86 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-VENV_DIR="${ROOT_DIR}/.venv"
-NODE_MODULES_DIR="${ROOT_DIR}/desktop_shell/node_modules"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT"
 
-if [[ ! -d "${VENV_DIR}" ]]; then
-  echo "Missing virtual environment at ${VENV_DIR}. Create it and install the project first." >&2
-  echo "Expected setup:" >&2
-  echo "  python3 -m venv .venv && source .venv/bin/activate && python -m pip install -e ." >&2
+if [ -f "$ROOT/.venv/bin/activate" ]; then
+  # shellcheck disable=SC1091
+  source "$ROOT/.venv/bin/activate"
+else
+  echo "Missing .venv. Create it with:"
+  echo "python -m venv .venv && source .venv/bin/activate && pip install -e ."
   exit 1
 fi
 
-# shellcheck disable=SC1091
-source "${VENV_DIR}/bin/activate"
-
 python - <<'PY'
-import importlib.util
-import sys
-
-if importlib.util.find_spec("nexus_os") is None:
-    sys.stderr.write("Nexus package is not installed in the active virtual environment.\n")
-    sys.stderr.write("Run: python -m pip install -e .\n")
+missing = []
+for mod in ["fastapi", "uvicorn", "nexus_os.product.api_server"]:
+    try:
+        __import__(mod)
+    except Exception as exc:
+        missing.append(f"{mod}: {exc}")
+if missing:
+    print("Missing API dependencies:")
+    print("Run: pip install -e . && pip install fastapi uvicorn")
     raise SystemExit(1)
 PY
 
-if [[ ! -d "${NODE_MODULES_DIR}" ]]; then
-  echo "Missing desktop dependencies at ${NODE_MODULES_DIR}." >&2
-  echo "Run: cd desktop_shell && npm install" >&2
+if [ ! -d "$ROOT/desktop_shell/node_modules" ]; then
+  echo "Missing desktop dependencies."
+  echo "Run: cd desktop_shell && npm install"
   exit 1
 fi
 
-cd "${ROOT_DIR}/desktop_shell"
-export NEXUS_PYTHON="${VENV_DIR}/bin/python"
-exec npm run desktop
+API_AUTH_TOKEN="${API_AUTH_TOKEN:-dev-api-token}"
+API_URL="${NEXUS_API_URL:-http://127.0.0.1:8765}"
+API_PID=""
+
+cleanup() {
+  if [ -n "${API_PID:-}" ]; then
+    kill "$API_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+api_ready() {
+  curl -fsS "$API_URL/api/state" -H "Authorization: Bearer $API_AUTH_TOKEN" >/dev/null 2>&1
+}
+
+if api_ready; then
+  echo "Nexus API already running at $API_URL"
+else
+  echo "Starting Nexus API at $API_URL"
+  API_AUTH_TOKEN="$API_AUTH_TOKEN" uvicorn nexus_os.product.api_server:app --host 127.0.0.1 --port 8765 >/tmp/nexus-api.log 2>&1 &
+  API_PID="$!"
+
+  for _ in $(seq 1 30); do
+    if api_ready; then
+      break
+    fi
+    sleep 0.5
+  done
+
+  if ! api_ready; then
+    echo "Nexus API did not become ready. Last API log:"
+    tail -n 80 /tmp/nexus-api.log || true
+    exit 1
+  fi
+fi
+
+cd "$ROOT/desktop_shell"
+
+if [ -n "${DISPLAY:-}" ]; then
+  echo "Launching Nexus Desktop: graphical mode"
+  npm run desktop
+else
+  if ! command -v xvfb-run >/dev/null 2>&1; then
+    echo "No DISPLAY and xvfb-run is not installed."
+    echo "In Codespaces run:"
+    echo "sudo apt-get update && sudo apt-get install -y xvfb libatk1.0-0t64 libatk-bridge2.0-0t64 libgtk-3-0t64 libnss3 libxss1 libasound2t64 libx11-xcb1 libxcomposite1 libxdamage1 libxrandr2 libgbm1"
+    exit 1
+  fi
+
+  echo "Launching Nexus Desktop: headless Codespaces mode via xvfb-run"
+  ELECTRON_DISABLE_GPU=1 xvfb-run -a ./node_modules/.bin/electron electron/main.js --disable-gpu --disable-software-rasterizer --no-sandbox
+fi

--- a/scripts/smoke_nexus_launch.py
+++ b/scripts/smoke_nexus_launch.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+import importlib
+import json
+import os
+import shutil
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def check_import(name: str) -> tuple[bool, str]:
+    try:
+        importlib.import_module(name)
+        return True, f"import {name}"
+    except Exception as exc:
+        return False, f"import {name}: {exc}"
+
+
+def main() -> int:
+    checks: list[dict[str, object]] = []
+
+    for module in ["fastapi", "uvicorn", "nexus_os.product.api_server"]:
+        ok, detail = check_import(module)
+        checks.append({"name": f"module:{module}", "ok": ok, "detail": detail})
+
+    launcher = ROOT / "launch_nexus_desktop.sh"
+    checks.append(
+        {
+            "name": "launcher_exists",
+            "ok": launcher.exists(),
+            "detail": str(launcher),
+        }
+    )
+    checks.append(
+        {
+            "name": "launcher_executable",
+            "ok": launcher.exists() and os.access(launcher, os.X_OK),
+            "detail": str(launcher),
+        }
+    )
+
+    package_json = ROOT / "desktop_shell" / "package.json"
+    checks.append(
+        {
+            "name": "desktop_package_json_exists",
+            "ok": package_json.exists(),
+            "detail": str(package_json),
+        }
+    )
+
+    electron_main = ROOT / "desktop_shell" / "electron" / "main.js"
+    checks.append(
+        {
+            "name": "desktop_electron_main_exists",
+            "ok": electron_main.exists(),
+            "detail": str(electron_main),
+        }
+    )
+
+    node_modules = ROOT / "desktop_shell" / "node_modules"
+    checks.append(
+        {
+            "name": "desktop_node_modules_exists",
+            "ok": node_modules.exists(),
+            "detail": str(node_modules),
+        }
+    )
+
+    display_set = bool(os.environ.get("DISPLAY"))
+    checks.append(
+        {
+            "name": "display_set",
+            "ok": True,
+            "detail": f"DISPLAY={'set' if display_set else 'missing'}",
+        }
+    )
+
+    if not display_set:
+        xvfb_exists = shutil.which("xvfb-run") is not None
+        checks.append(
+            {
+                "name": "xvfb_run_available",
+                "ok": xvfb_exists,
+                "detail": "xvfb-run found" if xvfb_exists else "xvfb-run missing",
+            }
+        )
+
+    payload = {
+        "ok": all(bool(item["ok"]) for item in checks),
+        "checks": checks,
+    }
+    print(json.dumps(payload))
+    return 0 if payload["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_nexus_desktop_launch_wrapper.py
+++ b/tests/test_nexus_desktop_launch_wrapper.py
@@ -1,0 +1,56 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_launcher_exists_and_executable() -> None:
+    launcher = ROOT / "launch_nexus_desktop.sh"
+    assert launcher.exists(), "launch_nexus_desktop.sh should exist"
+    assert os.access(launcher, os.X_OK), "launch_nexus_desktop.sh should be executable"
+
+
+def test_launcher_contains_required_markers() -> None:
+    launcher = ROOT / "launch_nexus_desktop.sh"
+    content = launcher.read_text(encoding="utf-8")
+
+    required_markers = [
+        "API_AUTH_TOKEN",
+        "uvicorn nexus_os.product.api_server:app",
+        "/api/state",
+        "DISPLAY",
+        "xvfb-run",
+        "--disable-gpu",
+        "--disable-software-rasterizer",
+        "--no-sandbox",
+        "Launching Nexus Desktop: headless Codespaces mode via xvfb-run",
+    ]
+
+    for marker in required_markers:
+        assert marker in content, f"Missing marker in launcher: {marker}"
+
+
+def test_smoke_script_exists_and_emits_json() -> None:
+    smoke_script = ROOT / "scripts" / "smoke_nexus_launch.py"
+    assert smoke_script.exists(), "scripts/smoke_nexus_launch.py should exist"
+
+    result = subprocess.run(
+        [sys.executable, str(smoke_script)],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+        check=False,
+    )
+
+    output = result.stdout.strip()
+    assert output, "Smoke script should output JSON"
+
+    payload = json.loads(output)
+    assert isinstance(payload, dict)
+    assert "ok" in payload
+    assert "checks" in payload
+    assert isinstance(payload["checks"], list)


### PR DESCRIPTION
## Summary

- Nexus API confirmed working on `/api/state` (port 8765)
- Botomatic on port 3000 is unrelated and untouched
- `launch_nexus_desktop.sh` now starts/probes API before launching desktop
- Launcher uses `xvfb-run` in Codespaces/headless mode (no DISPLAY)

## Changes

- **`launch_nexus_desktop.sh`** — Full headless-aware launcher: sources .venv, checks Python/Node deps, probes or starts API with 15s readiness wait, branches on DISPLAY presence, uses `ELECTRON_DISABLE_GPU=1 xvfb-run -a` when headless
- **`scripts/smoke_nexus_launch.py`** — Checks imports, launcher existence/executable, desktop deps, DISPLAY/xvfb-run availability; emits JSON
- **`tests/test_nexus_desktop_launch_wrapper.py`** — Pytest coverage for launcher existence, executable bit, required string content, and smoke script JSON output

## Validation Results

```
python scripts/smoke_nexus_launch.py       → {"ok": true, ...all checks pass}
pytest tests/test_nexus_desktop_launch_wrapper.py  → 3 passed
python scripts/validate_docs_truth_hygiene.py      → DOCS_TRUTH_HYGIENE_PASS
python scripts/validate_repo_truth_consistency.py  → REPO_TRUTH_CONSISTENCY_PASS
python scripts/run_ui_truth_scenarios.py           → 5 scenarios emitted
python scripts/validate_ui_truth.py                → all passed
python scripts/run_enterprise_gate.py              → all gates passed
python -m pytest tests                             → 57 passed
```

## Manual Launch Result (Codespaces)

```
Starting Nexus API at http://127.0.0.1:8765
Launching Nexus Desktop: headless Codespaces mode via xvfb-run
[ERROR:bus.cc] Failed to connect to the bus: ...  (DBus warning — acceptable)
```

## Notes

- Visual inspection in Codespaces is limited by headless environment (no real display)
- DBus "Failed to connect" warnings are expected and non-fatal in Codespaces
- `docs/release/RELEASE_MANIFEST.json` was not committed